### PR TITLE
Requisito de pacote desnecessário removido

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "fakerphp/faker": "^1.9.1",
         "laravel/pint": "^1.0",
         "laravel/sail": "^1.0.1",
-        "lucascudo/laravel-pt-br-localization": "^1.2",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^6.1",
         "phpunit/phpunit": "^9.5.10",


### PR DESCRIPTION
Como o pacote de locale simplesmente adiciona o diretório pt-Br, não é necessário baixá-lo novamente, já que a pasta está no projeto.

* A instalação desse pacote pode ocasionar em problemas e necessitaria da adição de um novo repositório para o composer.